### PR TITLE
test: add pytest scaffolding + 105 tests for pure-Python helpers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        # Runtime deps are needed because PathStatus lives in local_intel/
+        # which is a package whose __init__ pulls in the rest of the
+        # local_intel stack at import time. The test for PathStatus reaches
+        # through that import.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run pytest
+        run: python -m pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.pytest.ini_options]
+# Tests live in tests/ and are pure-Python — they intentionally do not import
+# anything that drags in PyQt or numpy at collection time. PyQt UI testing
+# would require pytest-qt and a display server; that's deferred.
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "-ra",                # Show summary of all non-passing outcomes
+    "--strict-markers",   # Unknown @pytest.mark.X is an error, not a typo
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Development-only dependencies for QSO Predictor.
+# Install with:
+#   pip install -r requirements.txt -r requirements-dev.txt
+
+pytest>=7.0.0

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,224 @@
+"""Tests for analyzer.geometry — pure helpers carved out of QSOAnalyzer.
+
+These functions have no side effects, no Qt state, no locks. They're the
+easiest piece of the codebase to test, and the most-used helpers in path
+classification + signal density calculations.
+"""
+
+import pytest
+
+from analyzer import geometry
+
+
+# --- freq_to_band ---------------------------------------------------------
+
+
+class TestFreqToBand:
+    """Map Hz frequencies to amateur band names."""
+
+    @pytest.mark.parametrize("freq_hz,expected", [
+        (1_840_000, "160m"),
+        (3_573_000, "80m"),
+        (5_357_000, "60m"),
+        (7_074_000, "40m"),
+        (10_136_000, "30m"),
+        (14_074_000, "20m"),
+        (14_076_000, "20m"),  # mid-band
+        (18_100_000, "17m"),
+        (21_074_000, "15m"),
+        (24_915_000, "12m"),
+        (28_074_000, "10m"),
+        (50_313_000, "6m"),
+    ])
+    def test_recognized_bands(self, freq_hz, expected):
+        assert geometry.freq_to_band(freq_hz) == expected
+
+    @pytest.mark.parametrize("freq_hz", [
+        0,
+        1_000_000,        # below 160m
+        4_500_000,        # between 80m and 60m
+        9_000_000,        # between 60m and 30m
+        15_000_000,       # between 20m and 17m
+        100_000_000,      # FM/VHF — unrecognized
+    ])
+    def test_unrecognized_returns_sentinel(self, freq_hz):
+        assert geometry.freq_to_band(freq_hz) == "??m"
+
+    def test_band_edges_inclusive(self):
+        # Band definitions in the function use `<=` on both ends. The 20m
+        # endpoints should both classify as 20m, not "??m".
+        assert geometry.freq_to_band(14_000_000) == "20m"
+        assert geometry.freq_to_band(14_350_000) == "20m"
+
+
+# --- is_callsign ----------------------------------------------------------
+
+
+class TestIsCallsign:
+    """Loose heuristic for "this string could be an amateur callsign."""
+
+    @pytest.mark.parametrize("call", [
+        "WU2C",
+        "JA1XYZ",
+        "G0ABC",
+        "DL1ABCD",
+        "VE3ABC",
+        "K1A",          # minimum length 3
+        "9V1AB",        # 5 chars
+        "ZL2/M0ABC",    # portable prefix
+    ])
+    def test_real_callsigns(self, call):
+        assert geometry.is_callsign(call) is True
+
+    @pytest.mark.parametrize("call", [
+        "",            # empty
+        "AB",          # too short (<3)
+        "ABCDEFGHIJK", # too long (>10)
+        "HELLO",       # no digit
+        "WU2C!",       # special char
+        "WU2C@HOME",   # @ is not allowed
+        None,          # not a string — guarded against by the `not s` check
+    ])
+    def test_non_callsigns(self, call):
+        assert geometry.is_callsign(call) is False
+
+    def test_heuristic_is_intentionally_loose(self):
+        # is_callsign is a fast first-pass filter for FT8 message parsing,
+        # not a real callsign validator. It accepts any alnum string of
+        # length 3-10 that contains at least one digit. This means pure-
+        # digit strings like "1234" pass — that's a documented limitation,
+        # not a bug. Downstream code does stricter validation when needed.
+        assert geometry.is_callsign("1234") is True
+
+    def test_angle_bracket_wrapping_is_stripped(self):
+        # FT8 messages occasionally wrap calls in angle brackets to indicate
+        # hashed/abbreviated representations. The heuristic strips them.
+        assert geometry.is_callsign("<WU2C>") is True
+
+
+# --- bearing_to_region ----------------------------------------------------
+
+
+class TestBearingToRegion:
+    """Coarse mapping from bearing-from-grid to DXCC region code."""
+
+    @pytest.mark.parametrize("bearing,expected", [
+        (0,    "NA"),    # due north (default branch)
+        (45,   "EU"),    # NE quadrant
+        (90,   "AF/ME"),
+        (135,  "AS"),
+        (180,  "OC"),
+        (225,  "OC"),    # wraps into OC range
+        (270,  "SA"),
+        (315,  "CA"),
+        (350,  "NA"),    # wraps back to NA via the default branch
+    ])
+    def test_known_bearings(self, bearing, expected):
+        assert geometry.bearing_to_region(bearing) == expected
+
+    def test_modulo_normalization(self):
+        # Bearings > 360 should wrap around.
+        assert geometry.bearing_to_region(360) == geometry.bearing_to_region(0)
+        assert geometry.bearing_to_region(450) == geometry.bearing_to_region(90)
+
+    def test_negative_bearings_normalize(self):
+        # Negative bearings should also wrap.
+        assert geometry.bearing_to_region(-90) == geometry.bearing_to_region(270)
+
+
+# --- max_concentration ----------------------------------------------------
+
+
+class TestMaxConcentration:
+    """Highest percentage of spots in any 3 adjacent sectors (135° arc)."""
+
+    def test_empty_sectors(self):
+        assert geometry.max_concentration([0] * 8) == 0
+
+    def test_single_direction(self):
+        # All spots in one sector: that sector + 2 neighbors = 100% of total.
+        sectors = [10, 0, 0, 0, 0, 0, 0, 0]
+        assert geometry.max_concentration(sectors) == 100
+
+    def test_uniform_distribution(self):
+        # 1 per sector: any 3 adjacent = 3/8 = 37%
+        sectors = [1] * 8
+        assert geometry.max_concentration(sectors) == 37
+
+    def test_partial_concentration(self):
+        # 3+1+0=4 of 4 spots = 100% in one 3-sector arc;
+        # but 3 of the 4 are also in N+NE+E (3+1+0=4/4=100%).
+        # Use a less degenerate case:
+        # NE=2, E=4, SE=2, rest=0. Total=8.
+        # NE+E+SE = 2+4+2 = 8/8 = 100%
+        sectors = [0, 2, 4, 2, 0, 0, 0, 0]
+        assert geometry.max_concentration(sectors) == 100
+
+    def test_split_distribution(self):
+        # Half in N region, half in S region.
+        # Total = 8. Best 3-arc concentration ≈ 4/8 = 50%.
+        sectors = [2, 1, 1, 0, 2, 1, 1, 0]
+        result = geometry.max_concentration(sectors)
+        # Best window is N+NE+NW or similar — should be 4/8 = 50
+        assert result == 50
+
+    def test_wraparound_window(self):
+        # Spots concentrated at N (sector 0) and NW (sector 7).
+        # The 3-sector window centered on N (NW, N, NE) should win.
+        sectors = [5, 0, 0, 0, 0, 0, 0, 5]
+        # NW=5 + N=5 + NE=0 = 10/10 = 100%
+        assert geometry.max_concentration(sectors) == 100
+
+
+# --- sector_distribution --------------------------------------------------
+
+
+class TestSectorDistribution:
+    """Bin spots into 8 compass sectors from a given grid."""
+
+    def test_empty_spots(self):
+        result = geometry.sector_distribution([], "FN42")
+        assert result == [0] * 8
+
+    def test_no_grid_skipped(self):
+        # Spots without grids should be silently skipped.
+        spots = [{"call": "ZZ1ZZZ"}, {"grid": "", "call": "X"}]
+        result = geometry.sector_distribution(spots, "FN42")
+        assert result == [0] * 8
+
+    def test_too_short_grids_skipped(self):
+        # Grids < 4 chars don't carry enough precision for bearing.
+        spots = [{"grid": "FN"}, {"grid": "JO"}, {"grid": ""}]
+        result = geometry.sector_distribution(spots, "FN42")
+        assert result == [0] * 8
+
+    def test_from_grid_empty_returns_zeros(self):
+        # If our own grid is missing, we have no anchor — return zeros.
+        result = geometry.sector_distribution(
+            [{"grid": "JO22AB"}], from_grid=""
+        )
+        assert result == [0] * 8
+
+    def test_counts_sum_matches_valid_spots(self):
+        # Mix of valid and invalid spots — count only the valid ones.
+        spots = [
+            {"grid": "JO22AB"},    # valid (Europe from FN42 ~ NE)
+            {"grid": "FN42MP"},    # valid (same as us — bearing undefined, but
+                                   # at least 4 chars; will land somewhere)
+            {"grid": ""},          # skipped
+            {"grid": "FN"},        # skipped (<4 chars)
+        ]
+        result = geometry.sector_distribution(spots, "FN42MP")
+        assert sum(result) == 2
+
+    def test_known_bearing_lands_in_correct_sector(self):
+        # FN42 → JO22 is roughly due east (~50° bearing).
+        # Sector 0 is N (0-45° centered on 22.5°), sector 1 is NE (45-90°).
+        # Bearing 50° / 45 = 1.11 → sector 1 (NE).
+        spots = [{"grid": "JO22AB"}]
+        result = geometry.sector_distribution(spots, "FN42MP")
+        # The actual bearing depends on calculate_bearing's implementation;
+        # what we assert is "exactly one spot was placed, in a single sector"
+        assert sum(result) == 1
+        nonzero = [i for i, c in enumerate(result) if c > 0]
+        assert len(nonzero) == 1

--- a/tests/test_path_status.py
+++ b/tests/test_path_status.py
@@ -1,0 +1,156 @@
+"""Tests for local_intel.models.PathStatus.
+
+PathStatus is the canonical domain type for path classification. Its
+display_label values are byte-identical to historic UI strings (and
+therefore persisted by the outcome recorder), so the contract is:
+  - display_label strings frozen
+  - from_display(label) round-trips for known labels
+  - from_display(garbage) returns UNKNOWN (defensive default)
+"""
+
+import pytest
+
+from local_intel.models import PathStatus
+
+
+# All canonical display labels — these strings are persisted by
+# outcome_recorder.py to ~/.qso-predictor/outcome_history.jsonl. Changing
+# them would break older log files.
+CANONICAL_LABELS = {
+    PathStatus.HEARD_BY_TARGET: "Heard by Target",
+    PathStatus.REPORTED_IN_REGION: "Reported in Region",
+    PathStatus.NOT_REPORTED_IN_REGION: "Not Reported in Region",
+    PathStatus.NOT_TRANSMITTING: "Not Transmitting",
+    PathStatus.NO_REPORTERS: "No Reporters in Region",
+    PathStatus.UNKNOWN: "",
+}
+
+
+class TestDisplayLabels:
+    """display_label strings are an external contract — verify each one."""
+
+    @pytest.mark.parametrize("status,expected", list(CANONICAL_LABELS.items()))
+    def test_display_label_frozen(self, status, expected):
+        assert status.display_label == expected
+
+    def test_all_states_have_display_label(self):
+        # If a new state is added without a display_label entry, this fails.
+        for status in PathStatus:
+            assert status.display_label is not None
+
+
+class TestFromDisplay:
+    """from_display(label) parses display strings back to enum values."""
+
+    @pytest.mark.parametrize("status,label", [
+        (PathStatus.HEARD_BY_TARGET, "Heard by Target"),
+        (PathStatus.REPORTED_IN_REGION, "Reported in Region"),
+        (PathStatus.NOT_REPORTED_IN_REGION, "Not Reported in Region"),
+        (PathStatus.NOT_TRANSMITTING, "Not Transmitting"),
+        (PathStatus.NO_REPORTERS, "No Reporters in Region"),
+    ])
+    def test_round_trip_recognized_labels(self, status, label):
+        assert PathStatus.from_display(label) == status
+
+    @pytest.mark.parametrize("garbage", [
+        "",                              # empty
+        "Heard",                         # partial / substring
+        "Reported",                      # partial
+        "Reported in Re",                # truncated
+        "heard by target",               # case-sensitive — lowercase shouldn't match
+        "Heard by Target!",              # trailing junk
+        "Some Future Status",            # unknown
+        "Not Reported in Regionx",       # extra char
+    ])
+    def test_unrecognized_returns_unknown(self, garbage):
+        assert PathStatus.from_display(garbage) == PathStatus.UNKNOWN
+
+    def test_substring_safety_not_reported_vs_reported(self):
+        # This is the bug class the enum was introduced to prevent:
+        # "Not Reported in Region" contains "Reported in Region" as a substring.
+        # from_display uses exact match, so both round-trip to their own status.
+        assert (
+            PathStatus.from_display("Not Reported in Region")
+            == PathStatus.NOT_REPORTED_IN_REGION
+        )
+        assert (
+            PathStatus.from_display("Reported in Region")
+            == PathStatus.REPORTED_IN_REGION
+        )
+
+
+class TestHasPathEvidence:
+    """has_path_evidence partitions the enum into 'real signal' vs 'no data'.
+
+    Predictor / strategy code uses this to treat UNKNOWN /
+    NOT_TRANSMITTING / NO_REPORTERS uniformly.
+    """
+
+    def test_evidence_states(self):
+        for status in (
+            PathStatus.HEARD_BY_TARGET,
+            PathStatus.REPORTED_IN_REGION,
+            PathStatus.NOT_REPORTED_IN_REGION,
+        ):
+            assert status.has_path_evidence is True, status
+
+    def test_no_evidence_states(self):
+        for status in (
+            PathStatus.UNKNOWN,
+            PathStatus.NOT_TRANSMITTING,
+            PathStatus.NO_REPORTERS,
+        ):
+            assert status.has_path_evidence is False, status
+
+
+class TestColorAndRowBackground:
+    """color and row_background back the dashboard + table rendering."""
+
+    def test_every_state_has_a_color(self):
+        # Each state must return a hex-ish string — the dashboard reads .color
+        # unconditionally.
+        for status in PathStatus:
+            color = status.color
+            assert isinstance(color, str)
+            assert color.startswith("#")
+            assert len(color) == 7  # #RRGGBB
+
+    def test_row_background_present_only_for_priority_states(self):
+        # Only HEARD_BY_TARGET and REPORTED_IN_REGION should have a row
+        # background highlight. Others fall through to default alternating rows.
+        assert PathStatus.HEARD_BY_TARGET.row_background is not None
+        assert PathStatus.REPORTED_IN_REGION.row_background is not None
+        for status in (
+            PathStatus.NOT_REPORTED_IN_REGION,
+            PathStatus.NOT_TRANSMITTING,
+            PathStatus.NO_REPORTERS,
+            PathStatus.UNKNOWN,
+        ):
+            assert status.row_background is None, status
+
+    def test_distinct_foreground_colors(self):
+        # The five visible-evidence states should have distinct foreground
+        # colors so users can distinguish them at a glance.
+        visible = [
+            PathStatus.HEARD_BY_TARGET,
+            PathStatus.REPORTED_IN_REGION,
+            PathStatus.NOT_REPORTED_IN_REGION,
+            PathStatus.NOT_TRANSMITTING,
+            PathStatus.NO_REPORTERS,
+        ]
+        colors = {s.color for s in visible}
+        assert len(colors) == len(visible), (
+            "Two visible PathStatus states share a color — users can't tell them apart"
+        )
+
+
+class TestShortLabels:
+    """short_label is used in space-constrained UI like the dashboard."""
+
+    def test_short_label_present_for_displayed_states(self):
+        for status in PathStatus:
+            assert status.short_label is not None
+            # short_label should be shorter or equal to display_label for the
+            # primary states where shortening is the whole point.
+            if status in (PathStatus.HEARD_BY_TARGET, PathStatus.REPORTED_IN_REGION):
+                assert len(status.short_label) <= len(status.display_label)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,97 @@
+"""Tests for utils.version — semver-ish comparison + version-string parsing.
+
+compare_versions feeds the GitHub update checker: it has to return True
+when a newer version is available, False when current is up-to-date or
+newer. Off-by-one bugs here would either spam users with phantom update
+notifications or hide real updates.
+"""
+
+import pytest
+
+from utils.version import compare_versions, get_version, is_packaged_install
+
+
+class TestCompareVersions:
+    """compare_versions(current, latest) -> True iff latest > current."""
+
+    @pytest.mark.parametrize("current,latest", [
+        ("1.0.0", "1.0.1"),
+        ("1.0.0", "1.1.0"),
+        ("1.0.0", "2.0.0"),
+        ("2.5.5", "2.5.6"),
+        ("2.5.5.1", "2.5.6"),
+        ("2.5", "2.5.1"),
+        ("0.9.99", "1.0.0"),
+    ])
+    def test_newer_returns_true(self, current, latest):
+        assert compare_versions(current, latest) is True
+
+    @pytest.mark.parametrize("current,latest", [
+        ("1.0.0", "1.0.0"),    # equal
+        ("1.0.1", "1.0.0"),    # current newer
+        ("2.0.0", "1.99.0"),   # current much newer
+        ("2.5.6", "2.5.5"),
+        ("2.5.6", "2.5.5.1"),
+    ])
+    def test_same_or_older_returns_false(self, current, latest):
+        assert compare_versions(current, latest) is False
+
+    def test_git_describe_format_handled(self):
+        # `git describe --tags` produces "2.5.5-3-gabcdef" for HEAD that is
+        # 3 commits past tag v2.5.5. The compare logic strips the suffix
+        # before integer comparison, so "2.5.5-3-gabcdef" should be treated
+        # as 2.5.5 for comparison purposes.
+        # 2.5.6 is greater than 2.5.5 → True
+        assert compare_versions("2.5.5-3-gabcdef", "2.5.6") is True
+        # 2.5.5 vs 2.5.5-3-gabcdef → both parse to 2.5.5, equal → False
+        assert compare_versions("2.5.5", "2.5.5-3-gabcdef") is False
+
+    def test_unparseable_falls_back_to_string_compare(self):
+        # Defensive fallback when version strings don't have integer parts.
+        # The fallback rule: True iff `latest != current and latest > current`
+        # (string comparison).
+        assert compare_versions("alpha", "beta") is True
+        assert compare_versions("beta", "alpha") is False
+        assert compare_versions("alpha", "alpha") is False
+
+    def test_different_length_versions(self):
+        # 2.5 vs 2.5.0 should be equal (shorter padded with zeros).
+        assert compare_versions("2.5", "2.5.0") is False
+        assert compare_versions("2.5.0", "2.5") is False
+
+
+class TestGetVersion:
+    """get_version reads from git describe, then VERSION file, then 'dev'."""
+
+    def test_returns_a_string(self):
+        # Either git describe gives us "X.Y.Z[-N-gXXX]" or VERSION file gives
+        # us "X.Y.Z" or we fall through to "dev". All are strings.
+        v = get_version()
+        assert isinstance(v, str)
+        assert len(v) > 0
+
+    def test_no_leading_v(self):
+        # Tags are "v2.5.6" but get_version strips the prefix.
+        v = get_version()
+        assert not v.startswith("v"), (
+            f"get_version() should strip leading 'v' from tag; got {v!r}"
+        )
+
+
+class TestIsPackagedInstall:
+    """is_packaged_install is Windows-only; returns False everywhere else."""
+
+    def test_returns_bool(self):
+        # On a non-Windows host (CI Linux runner, dev Mac), this returns False
+        # via the platform guard. On Windows, it returns True/False based on
+        # the MSIX detection. Either way: must be a bool.
+        result = is_packaged_install()
+        assert isinstance(result, bool)
+
+    def test_non_windows_returns_false(self):
+        # The function's first line is `if sys.platform != 'win32': return False`.
+        # This test verifies that contract on the platforms where it runs.
+        import sys
+        if sys.platform == 'win32':
+            pytest.skip("Windows-specific behavior; test asserts non-Windows contract")
+        assert is_packaged_install() is False


### PR DESCRIPTION
## Summary

First pass at automated testing for QSO Predictor. 105 tests covering the pure-Python pieces that don't need Qt or a display server.

Closes the biggest gap identified in the post-refactor code quality review: no automated tests meant every refactor was validated only by manual Mac + Windows app launches.

## What's covered

- **`analyzer.geometry`** — band recognition, callsign heuristic, bearing-to-region binning, max concentration calc (incl. wraparound), sector distribution input validation
- **`local_intel.models.PathStatus`** — display label byte-identity (these strings are persisted to disk by outcome_recorder; this test would catch any future rename), from_display round-trip, the substring-safety check that motivated the enum, has_path_evidence partitioning, color uniqueness
- **`utils.version`** — compare_versions across simple/padded/git-describe/unparseable inputs, get_version contract, is_packaged_install platform guard

## What's intentionally NOT covered yet

- QSOAnalyzer class (needs Qt + network state)
- Controllers (state lives on MainWindow, would need a fake)
- Widgets (would need pytest-qt + display server)

Those are follow-up additions if we want them — covered by the "Stage 7" note in DEVELOPMENT_NOTES.md.

## Infrastructure

- `requirements-dev.txt` — just `pytest` for now
- `pyproject.toml` — pytest config (testpaths, strict markers)
- `.github/workflows/tests.yml` — matrix on Python 3.10 / 3.11 / 3.12, Ubuntu

## Test plan

- [ ] CI runs green on all three Python versions
- [ ] 105 tests pass
- [ ] Workflow completes in well under 1 minute (locally: ~0.2s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)